### PR TITLE
refactor: use the new st4sd-runtime-core image

### DIFF
--- a/controllers/workflow_controller.go
+++ b/controllers/workflow_controller.go
@@ -871,9 +871,10 @@ func newPodForCR(r *WorkflowReconciler, cr *st4sdv1alpha1.Workflow) (*corev1.Pod
 	})
 
 	monitorElaunchContainer := corev1.Container{
-		Name:  "monitor-elaunch-container",
-		Image: options.WorkflowMonitoringImage,
-		Env:   envVars,
+		Name:    "monitor-elaunch-container",
+		Image:   options.WorkflowMonitoringImage,
+		Command: []string{"st4sd-k8s-monitor.py"},
+		Env:     envVars,
 		Lifecycle: &corev1.Lifecycle{
 			PreStop: &corev1.LifecycleHandler{
 				Exec: &corev1.ExecAction{
@@ -984,7 +985,7 @@ func newPodForCR(r *WorkflowReconciler, cr *st4sdv1alpha1.Workflow) (*corev1.Pod
 		}
 		volumeMountsPrimary = append(volumeMountsPrimary, volMountS3Fetch)
 
-		s3FetchCommand := []string{}
+		s3FetchCommand := []string{"st4sd-fetch-files.sh"}
 		s3EnvVars := []corev1.EnvVar{{Name: "ROOT_OUTPUT", Value: rootDirS3InputData}}
 
 		if cr.Spec.S3BucketInput.Dataset != "" {


### PR DESCRIPTION
The new image now contains the scripts for the utilities:
- st4sd-runtime-k8s-input-s3
- st4sd-runtime-k8s-monitoring

## Change list

Write a few bullet points of the changes contained in this PR:

- refactor: use the new st4sd-runtime-core image

## Checklist

Ensure your PR meets the following requirements:

- [ ] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
